### PR TITLE
Use v3 API for MyGet

### DIFF
--- a/src/BuildStats/PackageServices.fs
+++ b/src/BuildStats/PackageServices.fs
@@ -124,59 +124,62 @@ module Crate =
 
 [<RequireQualifiedAccess>]
 module MyGet =
-    open System.Net
     open System.Net.Http
     open Microsoft.FSharp.Core.Option
     open FSharp.Control.Tasks.V2.ContextInsensitive
     open Newtonsoft.Json.Linq
 
-    let skipIfNoPackageFound (json : string) =
-        match json with
-        | "{\"d\":[]}"  -> None
-        | _             -> Some json
-
-    let deserialize (downloadCountKey : string) (json : string) =
+    let deserialize (json : string) =
         let obj = Json.deserialize json :?> JObject
-        let data = obj.Value<JArray> "d"
-        {
-            Feed = "myget"
-            Name = data.[0].Value<string> "Id"
-            Version = data.[0].Value<string> "Version"
-            Downloads = data.[0].Value<int> downloadCountKey
-        }
+        obj.Value<JArray> "data"
 
-    let validatePackage packageName package =
-        if packageName |> Str.equalsCi package.Name
-        then Some package
-        else None
+    let tryFindByName  (packageName : string)
+                       (data        : JArray)  =
+        data |> Seq.tryFind(fun item -> item.Value<string> "id" |> Str.equalsCi packageName)
+
+    let mapSemVer200 (version : string) =
+        version.Split([| '+' |], 2).[0]
+
+    let convertIntoPackage (packageVersion : string option) (item : JToken) =
+        match packageVersion with
+        | None ->
+            {
+                Feed = "nuget"
+                Name = item.Value<string> "id"
+                Version = item.Value<string> "version" |> mapSemVer200
+                Downloads = item.Value<int> "totaldownloads"
+            } |> Some
+        | Some version ->
+            item.Value<JArray> "versions"
+            |> fun a -> a.Children()
+            |> Seq.tryFind(fun x ->
+                (x.Value<string> "version" |> mapSemVer200).Equals version)
+            |> function
+                | None -> None
+                | Some item ->
+                    {
+                        Feed = "nuget"
+                        Name = item.Value<string> "id"
+                        Version = item.Value<string> "version" |> mapSemVer200
+                        Downloads = item.Value<int> "totaldownloads"
+                    } |> Some
 
     let getPackageAsync (httpClient         : PackageHttpClient)
                         (subDomain          : string)
                         (feedName           : string,
                          packageName        : string)
-                        (_                  : bool)
+                        (includePreReleases : bool)
                         (packageVersion     : string option) =
         task {
-            let filter =
-                match packageVersion with
-                | None   -> sprintf "Id eq '%s'" packageName
-                | Some v -> sprintf "Id eq '%s' and Version eq '%s'" packageName v
-                |> WebUtility.UrlEncode
-
-            let downloadCountKey =
-                match packageVersion with
-                | Some _ -> "VersionDownloadCount"
-                | None   -> "DownloadCount"
-
-            let url = sprintf "https://%s.myget.org/F/%s/api/v2/Packages()?$filter=%s&$orderby=Published desc&$top=1" subDomain feedName filter
+            let url = sprintf "https://%s.myget.org/F/%s/api/v3/query?q=%s&skip=0&take=10&prerelease=%b&semVerLevel=2.0.0" subDomain feedName packageName includePreReleases
             let request = new HttpRequestMessage(HttpMethod.Get, url)
             let! json = httpClient.SendAsync request
             return
                 json
                 |> (Str.toOption
-                >> bind skipIfNoPackageFound
-                >> map (deserialize downloadCountKey)
-                >> bind (validatePackage packageName))
+                >> map deserialize
+                >> bind (tryFindByName packageName)
+                >> bind (convertIntoPackage packageVersion))
         }
 
     let getPackageFromOfficialFeedAsync (httpClient         : PackageHttpClient)

--- a/tests/BuildStats.Tests/PackageTests.fs
+++ b/tests/BuildStats.Tests/PackageTests.fs
@@ -134,15 +134,22 @@ module PackageTests =
     /// -------------------------------------
 
     [<Fact>]
-    let ``NEventSocket returns correct result``() =
-        let package = MyGet.getPackageFromOfficialFeedAsync httpClient ("neventsocket-prerelease", "NEventSocket") false None |> runTask
+    let ``FSharp.Core returns correct result``() =
+        let package = MyGet.getPackageFromOfficialFeedAsync httpClient ("dotnet-core", "FSharp.Core") false None |> runTask
 
-        package.Value.Name        |> shouldEqual "NEventSocket"
-        package.Value.Downloads   |> shouldBeGreaterThan 4
+        package.Value.Name        |> shouldEqual "FSharp.Core"
+        package.Value.Downloads   |> shouldBeGreaterThan 0
 
     [<Fact>]
     let ``MyGet Package written in lowercase returns correct result``() =
-        let package = MyGet.getPackageFromOfficialFeedAsync httpClient ("neventsocket-prerelease", "neventsocket") false None |> runTask
+        let package = MyGet.getPackageFromOfficialFeedAsync httpClient ("dotnet-core", "fsharp.core") false None |> runTask
+
+        package.Value.Name        |> shouldEqual "FSharp.Core"
+        package.Value.Downloads   |> shouldBeGreaterThan 0
+
+    [<Fact>]
+    let ``NEventSocket PreRelease package returns correct result``() =
+        let package = MyGet.getPackageFromOfficialFeedAsync httpClient ("neventsocket-prerelease", "NEventSocket") true None |> runTask
 
         package.Value.Name        |> shouldEqual "NEventSocket"
         package.Value.Downloads   |> shouldBeGreaterThan 4


### PR DESCRIPTION
This PR updates the query logic for MyGet to use their v3 API so that prerelease package filtering works again.

It looks like it stopped working at some point for some cases which was bugging me, so I started going around digging and from what I could tell manually doing the API requests, the server wasn't returning anything even when the flag is passed through for IsPrerelease true.

I explored their V3 API index, and worked out the URL to use for it, which is basically the same as NuGet.org's and works as expected.

The implementation basically a copy-paste of the NuGet.org implementation, but as I'm an F# n00b I juse did a copy paste of the method and updated it as appropriate. Happy to refactor it for anything that's duplicated with NuGet, but I might need a bit of guidance to do it correctly.

I've tested it locally with the badges I wanted to fix on localhost and they're behaving as I'd expect now, and I also tested the example packages from the README.

## Current

| URL | Badge |
|:--:|:--:|
| `https://buildstats.info/myget/aspnet-contrib/AspNet.Security.OAuth.Apple?includePreReleases=false` | [![MyGet](https://buildstats.info/myget/aspnet-contrib/AspNet.Security.OAuth.Apple?includePreReleases=false)](https://www.myget.org/feed/aspnet-contrib/package/nuget/AspNet.Security.OAuth.Apple) |
| `https://buildstats.info/myget/aspnet-contrib/AspNet.Security.OAuth.Apple?includePreReleases=true` | [![MyGet](https://buildstats.info/myget/aspnet-contrib/AspNet.Security.OAuth.Apple?includePreReleases=true)](https://www.myget.org/feed/aspnet-contrib/package/nuget/AspNet.Security.OAuth.Apple) |

## With Change

![image](https://user-images.githubusercontent.com/1439341/86945403-e3ac2980-c140-11ea-8fcf-312e7f63990a.png)
